### PR TITLE
added info object in options to allow send more info params

### DIFF
--- a/xray-reporter.js
+++ b/xray-reporter.js
@@ -51,11 +51,13 @@ const XrayReporter = (options, onPrepareDefer, onCompleteDefer, browser) => {
 
     const XrayService = require('./xray-service')(options);
 
+    const defaultInfo = {
+        description: options.description,
+        version: options.version
+    }
+
     let result = {
-        info: {
-            description: options.description,
-            version: options.version
-        },
+        info: options.info ? options.info : defaultInfo,
         tests: []
     };
 


### PR DESCRIPTION
Hi!

 I just add an info option to allow sending more fields like testPlan, so we can send executions linked.
If no info field, then the options description and version are used (defaultInfo), just to avoid a breaking change.
Thanks!